### PR TITLE
Do context a little differently

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ import (
 
 func main() {
 
-	wait := grace.NewWait()
+	wait, ctx := grace.NewWait()
 
 	err := wait.WaitWithFunc(func() error {
 		ticker := time.NewTicker(2 * time.Second)
@@ -40,9 +40,9 @@ func main() {
 				log.Printf("ticker 2s ticked\n")
 				// testcase what happens if an error occured
 				//return fmt.Errorf("test error ticker 2s")
-			case <-wait.Done():
+			case <-ctx.Done():
 				log.Printf("closing ticker 2s goroutine\n")
-				return wait.Err()
+				return ctx.Err()
 			}
 		}
 	})
@@ -71,7 +71,7 @@ import (
 
 func main() {
 
-	wait := grace.NewWait()
+	wait, ctx := grace.NewWait()
 
 	err := wait.WaitWithTimeoutAndFunc(15*time.Second, func() error {
 		ticker := time.NewTicker(2 * time.Second)
@@ -81,9 +81,9 @@ func main() {
 				log.Printf("ticker 2s ticked\n")
 				// testcase what happens if an error occured
 				//return fmt.Errorf("test error ticker 2s")
-			case <-wait.Done():
+			case <-ctx.Done():
 				log.Printf("closing ticker 2s goroutine\n")
-				return wait.Err()
+				return ctx.Err()
 			}
 		}
 	})


### PR DESCRIPTION
I think this is more the intended approach.  It's definitely a little
confusing the way errgroup wants you to do it, but I think they do it
that way for the exact same reason you hit: to avoid storing the context
inside the errgroup.  Because of that, instead of
```
g := errgroup.WithContext(ctx)
g.Go(func(ctx context.Context) error {
    // use ctx
})
```
they designed it as
```
g, ctx := errgroup.WithContext(ctx)
g.Go(func() error {
    // use ctx
})
```

Note that closing over the context the way I do in the examples is
probably necessary in real code even if you ignore the done-checking:
you can imagine you replace the ticker with something that may want the
context more generally (say, an HTTP request).